### PR TITLE
Fix npm auth script in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,7 @@ jobs:
       - node/install-packages
       - run:
           name: "Setup npm"
-          command: |
-            echo -e "\n//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
-            echo "@metronome-industries:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          command: echo -e "\n//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
           name: "Publish"
           command: npm publish


### PR DESCRIPTION
This was wrong in the template. Will fix it there too. We haven't noticed before because we don't create public npm repos much. 