### PR TITLE
Don't overwrite provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vanta-serverless-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vanta-serverless-plugin",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^26.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanta-serverless-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A plugin that tags serverless created resources with the tags Vanta requires for compliance.",
   "license": "Apache-2.0",
   "author": "Metronome Industries",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,20 +4,14 @@ class VantaServerlessPlugin {
     const serviceName =
       (serverless?.service?.service as any)?.name || serverless.service.service;
 
-    serverless.service.provider = {
-      ...(serverless.service.provider ?? {}),
-      deploymentBucketObject: {
-        name: null,
-        ...(serverless.service.provider?.deploymentBucketObject ?? {}),
-        blockPublicAccess: true, // This is by defualt true in serverless due to ACLs and policies, but we want to be explicit for Vanta
-        tags: {
-          VantaDescription: `A bucket which holds the source code for the ${serviceName} service used while deploying the lambda functions`,
-          VantaContainsUserData: "false", // Only source code no user data
-          VantaNonProd: (
-            serverless.service.provider.stage !== "prod"
-          ).toString(),
-          ...(serverless.service.provider?.deploymentBucketObject?.tags ?? {}),
-        },
+    serverless.service.provider.deploymentBucketObject = {
+      ...(serverless.service.provider?.deploymentBucketObject ?? {}),
+      blockPublicAccess: true, // This is by defualt true in serverless due to ACLs and policies, but we want to be explicit for Vanta
+      tags: {
+        VantaDescription: `A bucket which holds the source code for the ${serviceName} service used while deploying the lambda functions`,
+        VantaContainsUserData: "false", // Only source code no user data
+        VantaNonProd: (serverless.service.provider.stage !== "prod").toString(),
+        ...(serverless.service.provider?.deploymentBucketObject?.tags ?? {}),
       },
     };
   }


### PR DESCRIPTION
To be honest I don't really understand this, but in some newer versions of serverless overwriting provider means our changes aren't applied. There's definitely some sort of issue with losing the reference to the object causing a stale instance to be used when actually creating the cloudformation template.

In the repos where this was causing issues this fixes them, and it _also_ works in the repos weren't it _wasn't_ causing an issue, so for now I think this is fine. 

Long term we may want to find a better way to do this, and additionally I would like to add some tests with different serverless versions but have to figure out how best to write those tests.