### PR TITLE
Support serverless v3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 lib
 
 .DS_Store
+
+# ides
+.idea

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,18 @@ class VantaServerlessPlugin {
     // In later versions of serverless the service is just a string
     const serviceName =
       (serverless?.service?.service as any)?.name || serverless.service.service;
+    const deploymentBucketKey = serverless.version.startsWith("3")
+      ? "deploymentBucket"
+      : "deploymentBucketObject";
 
-    serverless.service.provider.deploymentBucketObject = {
-      ...(serverless.service.provider?.deploymentBucketObject ?? {}),
+    serverless.service.provider[deploymentBucketKey] = {
+      ...(serverless.service.provider?.[deploymentBucketKey] ?? {}),
       blockPublicAccess: true, // This is by defualt true in serverless due to ACLs and policies, but we want to be explicit for Vanta
       tags: {
         VantaDescription: `A bucket which holds the source code for the ${serviceName} service used while deploying the lambda functions`,
         VantaContainsUserData: "false", // Only source code no user data
         VantaNonProd: (serverless.service.provider.stage !== "prod").toString(),
-        ...(serverless.service.provider?.deploymentBucketObject?.tags ?? {}),
+        ...(serverless.service.provider?.[deploymentBucketKey]?.tags ?? {}),
       },
     };
   }


### PR DESCRIPTION
Serverless v3 switched the key from deploymentBucketObject to deploymentBucket, so check the version and change the key if it starts with 3.