### PR TITLE
Auto-add vanta description tag for lambda functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanta-serverless-plugin",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A plugin that tags serverless created resources with the tags Vanta requires for compliance.",
   "license": "Apache-2.0",
   "author": "Metronome Industries",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ class VantaServerlessPlugin {
 
     serverless.service.provider[deploymentBucketKey] = {
       ...(serverless.service.provider?.[deploymentBucketKey] ?? {}),
-      blockPublicAccess: true, // This is by defualt true in serverless due to ACLs and policies, but we want to be explicit for Vanta
+      blockPublicAccess: true, // This is by default true in serverless due to ACLs and policies, but we want to be explicit for Vanta
       tags: {
         VantaDescription: `A bucket which holds the source code for the ${serviceName} service used while deploying the lambda functions`,
         VantaContainsUserData: "false", // Only source code no user data
@@ -17,6 +17,14 @@ class VantaServerlessPlugin {
         ...(serverless.service.provider?.[deploymentBucketKey]?.tags ?? {}),
       },
     };
+
+    const functionNames = Object.keys(serverless.service.functions);
+    functionNames.forEach((functionName) => {
+      serverless.service.functions[functionName].tags = {
+        VantaDescription: `${functionName} lambda function`,
+        ...serverless.service.functions[functionName].tags,
+      };
+    });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ class VantaServerlessPlugin {
     const functionNames = Object.keys(serverless.service.functions);
     functionNames.forEach((functionName) => {
       serverless.service.functions[functionName].tags = {
-        VantaDescription: `${functionName} lambda function`,
+        VantaDescription: `${functionName} AWS lambda function`,
         ...serverless.service.functions[functionName].tags,
       };
     });


### PR DESCRIPTION
This will auto-add a vanta description tag for our lambdas being created via serverless (and of course, utilizing this plugin). The description will be "<whatever you named the lambda in your serverless.yml under `functions:`> AWS lambda function"

--

Tested with some console logs by editing the `lib/index.js` of the plugin in repos like `alerts`
```
const functionNames = Object.keys(serverless.service.functions);
console.log(functionNames);
functionNames.forEach((functionName) => {
  console.log(serverless.service.functions[functionName].tags);
  serverless.service.functions[functionName].tags = {
    VantaDescription: `${functionName} lambda function`,
    ...serverless.service.functions[functionName].tags,
  };
  console.log(serverless.service.functions[functionName].tags);
});
```

Result:
```
// function names
[
  'customerAlertsProcessor',
  'customerAlertsDelayedProcessor',
  'customerAlertsAffectedCustomersProcessor',
  'customerAlertsNotificationsProcessor',
  'customerAlertsTracers',
  'customerAlertsLoadTest',
  'customerAlertsReflowDLQ',
  'dailyCustomerProcessor',
  'customerAlertsCreditGrantsProcessor',
  'customerAlertsServicePeriodsProcessor',
  'asyncDirectToKafkaTaskProcessor',
  'asyncDelayedTaskProcessor'
]
// function that had tags already set in serverless.yml
{ test: 'asdfasdf' }
// end result of existing tags + new vanta description tag
{
  VantaDescription: 'customerAlertsProcessor lambda function',
  test: 'asdfasdf'
}
```

Also tested that if the function already had a vanta description tag set in `serverless.yml` that it would overwrite the default `X AWS lambda function` tag this plugin is trying to write